### PR TITLE
Update GitHub Actions workflow for so it only runs on windows and linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build craw on Linux
         if: runner.os != 'Windows'
         run: make -f Makefile.mk all
-
+      
       # Upload craw artifact
       - name: Upload craw artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-22.04, windows-latest]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       # Checkout the repo
@@ -51,3 +51,4 @@ jobs:
           name: craw-binary-${{ matrix.os }}
           path: |
             craw*
+


### PR DESCRIPTION
---
name: Update GitHub Actions workflow for so it only runs on windows and linux
about: This removed Ubuntu 22.04 
title: Update GitHub Actions workflow for so it only runs on windows and linux
labels: 
assignees: @speedskater1610 
---

## Summary
Provide a brief overview of what this pull request does.  
Example: *"Add new lexer functionality to more safely and efficiently handle floating-point literals."*

## Changes
- Just removes Ubuntu specific version (we still have latest Ubuntu).

## Motivation
This solves that workflows are taking forever to build and are pretty slow so this improves speed by ~33%.

## Checklist
- [ ] Code compiles successfully
- [x] Tests pass (if applicable)
- [x] Code follows style guidelines
- [x] Documentation updated (if applicable)